### PR TITLE
The eager autoload discussed in Issue #3

### DIFF
--- a/lib/em_aws.rb
+++ b/lib/em_aws.rb
@@ -5,6 +5,7 @@ require 'em-synchrony'
 require 'em-synchrony/em-http'
 require 'aws/core/autoloader'
 
+AWS.eager_autoload! # lazy load isn't thread safe
 module AWS
   module Core
     module Http


### PR DESCRIPTION
Since I presume everybody using this already sets eager-autoload, I don't think this has a big risk of changing the project. 

Note: If someone deploys without a Gemfile.lock, they could get this new code without seeing it in development, and amazon might be pulling in a third party library that isn't in the Gemfile. Presumably no one does that, though (and they also have amazon's dependencies installed), and since the loading is eager, they'll see they don't have all the deps the aws sdk needs instantly anyway. Just thought I would mention this, in case it's a concern. A minor version change probably wouldn't be out of place to help make sure people can avoid this problem. 
