### PR TITLE
fixes S3Object#head not work

### DIFF
--- a/lib/aws/core/http/em_http_handler.rb
+++ b/lib/aws/core/http/em_http_handler.rb
@@ -123,8 +123,10 @@ module AWS
           rescue Timeout::Error, Errno::ETIMEDOUT => e
             response.timeout = true
           else
-            response.body = http_response.response
             response.status = http_response.response_header.status.to_i
+            if response.status < 300
+              response.body = http_response.response
+            end
             response.headers = http_response.response_header.raw.to_hash
           end
         end


### PR DESCRIPTION
modified line 125-.

problem:
1. EM::HttpRequest replace '-' to '_' in http-header.
2. When server returns response error (ex. 404), response.body is blank string not nil.
    AWS::S3.new.buckets[ YOUR_BUCKET ].objects[ MISSING_PATH ].head
