### PR TITLE
only set the HotTub logger if the AWS logger exists

### DIFF
--- a/lib/em_aws.rb
+++ b/lib/em_aws.rb
@@ -8,5 +8,5 @@ require 'aws/core/http/em_http_handler'
 require 'hot_tub'
 
 AWS.eager_autoload! # lazy load isn't thread safe
-HotTub.logger = AWS.config.logger
+HotTub.logger = AWS.config.logger if AWS.config.logger
 module EmAws;end


### PR DESCRIPTION
The AWS gem allows the logger to be `nil`, causing this issue:

```
An error occurred in an after hook
  NoMethodError: undefined method `info' for nil:NilClass
  occurred at /Users/kbishop/.rvm/gems/ruby-2.0.0-p195@n/gems/hot_tub-0.2.6/lib/hot_tub/pool.rb:164:in `_add'
```
